### PR TITLE
new: usr: Updated various components.

### DIFF
--- a/config/available/scheduled_events_to_s3.conf
+++ b/config/available/scheduled_events_to_s3.conf
@@ -3,7 +3,7 @@ module = scheduler
 
 [task_config]
 task_name = events_to_s3
-image = docker.io/halotools/halo-events-archiver:feature_CS-555
+image = docker.io/halotools/halo-events-archiver:v0.12
 retry = 5
 read_only = false
 

--- a/config/available/scheduled_scans_to_s3.conf
+++ b/config/available/scheduled_scans_to_s3.conf
@@ -3,7 +3,7 @@ module = scheduler
 
 [task_config]
 task_name = scans_to_s3
-image = docker.io/halotools/halo-scans-archiver:feature_CS-554
+image = docker.io/halotools/halo-scans-archiver:v0.18
 retry = 5
 read_only = false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3.4'
 x-halocelery_version:
-  &default_halocelery_version docker.io/halotools/halocelery:feature_CS-546
+  &default_halocelery_version docker.io/halotools/halocelery:v0.8
 x-donbot_version:
-  &default_donbot_version docker.io/halotools/don-bot:feature_CS-546
+  &default_donbot_version docker.io/halotools/don-bot:v0.19
 x-celery_env_vars:
   &default_celery_env_vars
   CELERY_BACKEND_URL: redis://redis
@@ -167,10 +167,8 @@ services:
       #####################################
       # Donbot's containerized task image versions
       #####################################
-      EC2_HALO_DELTA_VERSION: v0.1
-      FIREWALL_GRAPH_VERSION: 0.1.1
-      SCANS_TO_S3_VERSION: v0.17
-      EVENTS_TO_S3_VERSION: v0.10
+      EC2_HALO_DELTA_VERSION: v0.2
+      FIREWALL_GRAPH_VERSION: v0.2
     networks:
       - cortex
 


### PR DESCRIPTION
Updated halocelery to v0.8.  Enables file-based configuration for scheduler.  Introduce generic launch tasks for scheduled and ad-hoc tasks.
Closes #52

Updated don-bot to v0.19.  Don-bot now uses halocelery's generic container launch tasks for all ad-hoc containerized tasks.  Improvements to Slack integration allow more graceful handling of errors when communicating with Slack's API.  This version of don-bot is based on halocelery v0.8.
Closes #50

Pinned versions for events shipper and scan shipper (see scheduled_events_to_s3.conf and scheduled_scans_to_s3.conf in config/available/) to v0.12 and v0.18, respectively.
Closes #49